### PR TITLE
Parameter support for apache drill

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ For Apache Drill this would be
     con.password = "Password"
     con.authenticationType = "Plain"
     con.connectionType = "Direct"
-    con.zkClusterID = "drillbits1"
 
     if not con.connect:
       echo "Could not connect to database.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ODBC for Nim
 This module extends the odbcsql wrapper to allow easy access to databases through ODBC.
 
-The primary goal is to give Nim simpler access to Microsoft SQL Server in particular. Note that all of the testing for this module has been performed on SQL Server, though it should be possible to use any ODBC driver. However, you may need to manually set the connection string as other drivers may use different nomenclature and/or have different capabilities.
+The primary goal is to give Nim simpler access to Microsoft SQL Server in particular. This module has been tested on SQL Server and Apache Drill, though it should be possible to use any ODBC driver. However, you may need to manually set the connection string as other drivers may use different nomenclature and/or have different capabilities.
 
 Database access consists of two main objects: ODBCConnection and Query.
 
@@ -14,10 +14,10 @@ Connections can be initialised as follows:
     con.driver = "SQL Server Native Client 11.0"
     con.host = "ServerAddress"
     con.database = "DatabaseName"
-    
+
     if not con.connect:
       echo "Could not connect to database."
-      
+
 Connection authentication can be set to "integrated security", which will use your current security context (in Windows), or you can specify a username and password manaully.
 
     con.integratedSecurity = true # Use your current logged on Windows user to access the database.
@@ -27,6 +27,24 @@ or
     con.integratedSecurity = false
     con.userName = "Username"
     con.password = "Password"
+
+For Apache Drill this would be
+
+    ```nim
+    var
+      con = newODBCConnection(server=ApacheDrill)
+    con.driver = "/opt/mapr/drill/lib/64/libdrillodbc_sb64.so"
+    con.host = "ServerAddress"
+    con.port = 31010
+    con.integratedSecurity = false
+    con.userName = "Username"
+    con.password = "Password"
+    con.authenticationType = "Plain"
+    con.connectionType = "Direct"
+    con.zkClusterID = "drillbits1"
+
+    if not con.connect:
+      echo "Could not connect to database.```
 
 The connection object also offers some convenience settings such as multipleActiveResultSets, which tells ODBC that you want to be able to run multiple queries at the same time - for instance, if you need to use a lookup query whilst another query is active. This is set to true by default.
 
@@ -61,7 +79,7 @@ Transactions can be controlled using the beginTrans and commitTrans procs, and a
     con.beginTrans
     # do work using any query that's set to use this connection
     con.commitTrans
-  
+
 ## Queries
 
 Queries are the fundamental mechanism for running SQL.
@@ -164,7 +182,7 @@ Here we use two different methods of working with results from a simple query.
 Note that the statement is set only once, and in both examples the opening/closing of the query is performed behind the scenes.
 
     qry.statement = "SELECT 'A' AS A, 5 AS B, 0.8 AS C"
-    
+
     qry.withExecute(row):
       for item in row:
         if item.field.fieldname == "A": echo "A is found!"
@@ -192,7 +210,7 @@ Parameters are set by value by using their name as follows:
 
 Parameters are defined internally when you set the statement for the query, and will raise an error if you try to set a value for one that isn't referenced in the statement string.
 Parameters can also be used multiple times in the same query without having to redefine them. This is different from normal odbc, where you must apply the same value to different parameters if you want to use it more than once.
-For example: 
+For example:
 
     qry.statement = "SELECT ?a, ?a+?a, ?a*?a"
     qry.params["a"] = 10
@@ -205,10 +223,10 @@ You can convert results, rows or individual SQLValue objects to JSON format usin
 
     qry.statement = "SELECT 'A', 'B', 'C'
     var results = qry.executeFetch
-    
+
     from json import pretty # This allows us to convert json to human readable form for the echo
     echo results.toJson.pretty
-        
+
 ## Utilities
 
 You can list the available drivers on your system with:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ or
 
 For Apache Drill this would be
 
-    ```nim
     var
       con = newODBCConnection(server=ApacheDrill)
     con.driver = "/opt/mapr/drill/lib/64/libdrillodbc_sb64.so"
@@ -44,7 +43,7 @@ For Apache Drill this would be
     con.zkClusterID = "drillbits1"
 
     if not con.connect:
-      echo "Could not connect to database.```
+      echo "Could not connect to database.
 
 The connection object also offers some convenience settings such as multipleActiveResultSets, which tells ODBC that you want to be able to run multiple queries at the same time - for instance, if you need to use a lookup query whilst another query is active. This is set to true by default.
 

--- a/odbc.nim
+++ b/odbc.nim
@@ -205,7 +205,11 @@ template setup(qry: var SQLQuery) =
 
 template bindParams(qry: var SQLQuery) =
   # in place substitution for a bit less typing
-  qry.handle.bindParams(qry.params, qry.con.reporting)
+  #apache drill has no concept of parameters so we resolve them before sending query
+  if qry.con.serverType == ApacheDrill:
+    qry.odbcStatement.bindParams(qry.params, qry.con.reporting)
+  else:
+    qry.handle.bindParams(qry.params, qry.con.reporting)
 
 proc getColDetails(qry: SQLQuery, colID: int): SQLColDetails =
   # get a column's metadata

--- a/odbcconnections.nim
+++ b/odbcconnections.nim
@@ -1,6 +1,7 @@
 import odbcsql, odbcerrors, strutils, odbchandles, odbcreporting, tables
 
 type
+  ODBCServerType = enum SQLSever,ApacheDrill
   ODBCTransactionMode = enum tmAuto, tmManual
 
   ODBCConnection* = ref object
@@ -17,10 +18,15 @@ type
     provider*: string
     integratedSecurity*: bool
     connected: bool
+    serverType:ODBCServerType
     transMode: ODBCTransactionMode
     multipleActiveResultSets*: bool
     autoTranslate*: bool
     encrypted*: bool
+    authenticationType*:string
+    connectionType*:string
+    zkClusterID*:string
+    port*:int
     reporting*: ODBCReportState
 
 var
@@ -104,10 +110,19 @@ proc getConnectionString*(con: var ODBCConnection): string =
     params.add("Mars_Connection=Yes")
   if con.encrypted:
     params.add("Encrypt=yes")
+  if not con.authenticationType.isNil():
+    params.add("AuthenticationType=" & con.authenticationType)
+  if not con.connectionType.isNil():
+    params.add("connectionType=" & con.connectionType)
+  if con.port > 0:
+    params.add("Port=" & $con.port)
+  if not con.zkClusterID.isNil():
+    params.add("ZKClusterID=" & con.zkClusterID)
   if con.autoTranslate:
     params.add("AutoTranslate=Yes")
   else:
     params.add("AutoTranslate=No")
+
 
   result = join(params, ";")
 

--- a/odbcconnections.nim
+++ b/odbcconnections.nim
@@ -1,7 +1,7 @@
 import odbcsql, odbcerrors, strutils, odbchandles, odbcreporting, tables
 
 type
-  ODBCServerType = enum SQLSever,ApacheDrill
+  ODBCServerType* = enum SQLSever,ApacheDrill
   ODBCTransactionMode = enum tmAuto, tmManual
 
   ODBCConnection* = ref object
@@ -61,7 +61,7 @@ proc finaliseConnections {.noconv.} =
     pair[1].freeConnection
   when defined(odbcdebug): echo "Finalising connections done"
 
-proc newODBCConnection*(driver: string = "", host: string = "", database: string = ""): ODBCConnection =
+proc newODBCConnection*(driver: string = "", host: string = "", database: string = "",server:ODBCServerType = SQLSever): ODBCConnection =
   new(result, freeConnection)
   result.connectionString = ""
   result.driver = driver
@@ -76,6 +76,7 @@ proc newODBCConnection*(driver: string = "", host: string = "", database: string
   # Use SQL Server Native Client by default
   result.driver = "SQL Server Native Client 11.0"
   result.provider = ""
+  result.serverType = server
   result.reporting = newODBCReportState()
   result.reporting.level = defaultReportingLevel
   result.reporting.destinations = {rdStore}


### PR DESCRIPTION
apache drill has no concept of parameters. The thinking here is a developer can specify what kind of sever he is connecting to when creating a connection. By default, the server type is SQL Server.
Parameter substitution would then happen if server type is Drill before sending query