### PR TITLE
Fix nanosecond time

### DIFF
--- a/tests/all.nim
+++ b/tests/all.nim
@@ -74,13 +74,12 @@ for conDetails in connections.mitems:
       check res[0][1].intVal == 1
 
     # TODO: Times loses nanoseconds when converted to SQL time
-    #[test "Times":
+    test "Times":
       let curTime = getTime()
       qry.statement = "SELECT ?a"
       qry.params["a"] = curTime
       res = qry.executeFetch
       check res[0][0].timeVal == curTime.toTimeInterval
-    ]#
 
     test "Nulls":
       qry.statement = "SELECT ?a"


### PR DESCRIPTION
Fix for #6 
The implementation is a temporary workaround until https://github.com/nim-lang/Nim/issues/9771 is solved, at which point the temporary struct will be removed and `SQL_TIMESTAMP_STRUCT` can be used.