### PR TITLE
Version 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Connections can be initialised as follows:
     if not con.connect:
       echo "Could not connect to database."
 
-Connection authentication can be set to "integrated security", which will use your current security context (in Windows), or you can specify a username and password manaully.
+Connection authentication can be set to "integrated security", which will use your current security context (in Windows), or you can specify a username and password manually.
 
     con.integratedSecurity = true # Use your current logged on Windows user to access the database.
 
@@ -61,14 +61,14 @@ Information that is reported can be set to multiple destinations.
 
 Destination options are:
 * rdStore: Stores any messages in the connection under reporting.messages, which is a seq[string].
-* rdEcho: Echos messages to the display.
+* rdEcho: `echo` messages to the display.
 * rdFile: Stores messages in a file. The filename is defined under the connection in reporting.filename.
 * rdCallBack: Passes any messages to a custom procedure you may assign to the connection under reporting.callBack
 
 By default, reporting is set to rdEcho.
 
     con.reporting.level = rlErrorsAndInfo           # Will report any errors and also relevant database information
-    con.reporting.destinations = {rdStore, rdEcho}  # Stores in con.reporting.messages and echos them to the display
+    con.reporting.destinations = {rdStore, rdEcho}  # Stores in con.reporting.messages and echoes them to the display
 
 #### Transactions
 
@@ -116,7 +116,7 @@ or in one go with the fetch proc:
 
 #### withExecute
 
-This is a template that allows you to process each row, and is equivilent to opening a query and performing fetchRow, then calling close when the query's data has been depleted.
+This is a template that allows you to process each row, and is equivalent to opening a query and performing fetchRow, then calling close when the query's data has been depleted.
 
     qry.withExecute(row):
       # the variable, in this case 'row', within the brackets above is declared as SQLRow within the template
@@ -161,7 +161,7 @@ Alternatively, data can be accessed via field name with the `data` procs:
 SQLResults also allows working with SQLFields via the `fields` procs.
 
     let
-      # Fields can be retreived by column index or name.
+      # Fields can be retrieved by column index or name.
       fieldCol5 = results.fields(5)
       myField = results.fields(fieldnameString)
 

--- a/README.md
+++ b/README.md
@@ -140,20 +140,65 @@ SQLData elements are a variant object, and can be of several different types.
 * int64Val: Int64
 * boolVal: Bool
 * floatVal: Float
-* timeVal: Time. This is of timeInterval type so we can store milliseconds.
-* binVal: Binary. Stored as a seq[byte].
+* timeVal: Time. Stored as `TimeInterval`.
+* binVal: Binary. Stored as a `seq[byte]`.
 
-Data from a result set can be accessed via field with the fieldData proc:
+Data from a result set can be accessed directly using indexes.
 
-  var data = results.fieldData(fieldnameString, rowIdx)
+    let data = results[rowIdx][columnIdx]
 
-If you don't specify a rowIdx (or provide a value < 0) the data is retrieved from the row indicated by the results.curRow variable
+Alternatively, data can be accessed via field name with the `data` procs:
 
-Alternatively, data can be access directly via:
+    let
+      # Via numeric indexes
+      data1 = results.data(columnIndex)               # Use current row (results.curRow)
+      data2 = results.data(columnIndex, rowIndex)     # This is the same as results[rowIdx][columnIdx]
 
-  var data = results[rowIdx][columnIdx]
+      # Via field names
+      data3 = results.data(fieldnameString)
+      data4 = results.data(fieldnameString, rowIdx)
+    
+SQLResults also allows working with SQLFields via the `fields` procs.
 
+    let
+      # Fields can be retreived by column index or name.
+      fieldCol5 = results.fields(5)
+      myField = results.fields(fieldnameString)
 
+      # Access the data via SQLField for the current row.
+      data5 = results.data(fieldCol5)
+      myData = results.data(myField)
+      
+      # Access by SQlQField and row index.
+      data5AtRow = results.data(fieldCol5, rowIdx)
+      myDataAtRow = results.data(myField, rowIdx)
+
+#### Working with fields ####
+
+For large result sets, performing many calls to `data` with a string fieldname parameter is wasteful
+due to having to perform a hash table lookup with the field string each time.
+
+Fetching fields or field indexes allows faster processing:
+
+    let
+      results = myQuery.executeFetch
+      myField = results.fields("MyField")
+      
+    for i in 0 ..< results.len:
+      let data = results.data(myField, i)
+      # ... 
+
+Alternatively you can fetch the column index directly using `fieldIndex`:
+
+    let
+      results = myQuery.executeFetch
+      myFieldColIdx = results.fieldIndex("MyField")
+      
+    for i in 0 ..< results.len:
+      let data1 = results.data(myFieldColIdx, i)
+      # or
+      let data2 = results[i][myFieldColIdx]
+      # ... 
 
 #### Data conversions
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+0.1.3
+  * Internal fixes for 1.0.
 0.1.2
   * Removed `isNil` from strings.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,23 @@
+0.2.0
+  * Added `asBinary` support for times. All field types now allow conversion to `seq[byte]`.
+  * Added `tryData` for `SQLResults`, allowing speculatively fetching values without raising an error if the field doesn't exist.
+  * Added `fieldIndex`, `fields`, and `hasField` procs for `SQLResults`.
+  * Added millisecond and microsecond population for time fields.
+    Times now have microseconds and milliseconds populated and nanoseconds are appropriately truncated by default.
+  * Added `distributeNanoseconds` to manually invoke sub-second field population from `nanoseconds` on a `TimeInterval`.
+  * Added `stuffNanoseconds` to assemble the fractional part of a `TimeInterval` to nanoseconds.
+  * Added `odbcRawTimes` compile-time switch to avoid populating milliseconds and microseconds or truncating nanoseconds.
+    This leaves the entire sub-second fractional component represented in nanoseconds.
+  * Added tests for `data`, `tryData`, `fieldIndex`, and `listDrivers`.
+  * Exposed `SQLDriverAttribute`.
+  * Deprecated `fromField` used with SQLResults, as it now does the same work as `data`.
+  * `data` doesn't need `var SQLResults` any more.
+  * Removed the internal variable `fieldNames`, a functional duplicate of `fieldnamesIndex` in SQLResults.
+  * Tidied up the date time test, add option to only check times up to seconds precision.
+
 0.1.3
   * Internal fixes for 1.0.
+
 0.1.2
   * Removed `isNil` from strings.
 

--- a/odbc.nim
+++ b/odbc.nim
@@ -17,7 +17,7 @@ import
   odbc / [odbctypes, odbcerrors, odbcreporting],
   strformat
 
-export odbctypes, odbcreporting
+export odbctypes, odbcreporting, odbcerrors
 
 # this import includes the handles module and also imports odbcerrors
 include

--- a/odbc.nim
+++ b/odbc.nim
@@ -177,8 +177,6 @@ proc fetch*(qry: SQLQuery): SQLResults =
   # copy over fields as they'll be the same as the query
   # Note that colIndex should already be set up and match our result columns
   result.colFields = qry.colFields
-  for i in 0 ..< qry.colFields.len:
-    result.fieldnames.add(qry.colFields[i].fieldname, i)
   var newRow = initSQLRow()
   while qry.fetchRow(newRow):
     result.add(newRow)

--- a/odbc.nimble
+++ b/odbc.nimble
@@ -1,11 +1,11 @@
 # Package
-version       = "0.1.3"
+version       = "0.2.0"
 author        = "coffeepots"
 description   = "ODBC library around the odbcsql wrapper"
 license       = "MIT"
 
 # Deps
-requires: "nim >= 0.19"
+requires: "nim >= 1.0"
 
 # Tests
 task test, "Runs odbc test suite":

--- a/odbc/odbcfields.nim
+++ b/odbc/odbcfields.nim
@@ -35,6 +35,13 @@ proc add*(results: var SQLResults, row: SQLRow) =
 
 proc fields*(results: SQLResults, index: int): SQLField = results.colFields[index]
 
+proc fields*(results: SQLResults, fieldName: string): SQLField =
+  let idx = results.fieldnameIndex.getOrDefault(fieldName.toLowerAscii, -1)
+  if idx >= 0:
+    results.colFields[idx]
+  else:
+    raise newODBCUnknownFieldException("Fieldname not found \"" & fieldName & "\"")
+
 proc len*(results: SQLResults): int = results.rows.len
 
 proc index*(results: SQLResults, name: string): int =

--- a/odbc/odbcfields.nim
+++ b/odbc/odbcfields.nim
@@ -65,7 +65,10 @@ proc tryData*(results: SQLResults, fieldName: string, rowIdx: int, value: var SQ
   true
 
 ## Populates `value` from the current row if the field exists and returns true, otherwise returns false.
-template tryData*(results: SQLResults, fieldName: string, value: var SQLData): bool = results.tryData(fieldName, results.curRow, value)    
+template tryData*(results: SQLResults, fieldName: string, value: var SQLData): bool = results.tryData(fieldName, results.curRow, value)
+
+## Check by name to see if a result set contains a field.
+proc hasField*(results: SQLResults, fieldName: string): bool = results.fieldnameIndex.getOrDefault(fieldName.toLowerAscii, -1) != -1
 
 proc data*(results: SQLResults, fieldName: string, rowIdx: int = -1): SQLData =
   ## Return the SQLData associated with a field and row in `results`.

--- a/odbc/odbcfields.nim
+++ b/odbc/odbcfields.nim
@@ -42,6 +42,12 @@ proc fields*(results: SQLResults, fieldName: string): SQLField =
   else:
     raise newODBCUnknownFieldException("Fieldname not found \"" & fieldName & "\"")
 
+## Fetch the column index for `fieldName`. Raises an exception if the field can't be found.
+proc fieldIndex*(results: SQLResults, fieldName: string): int =
+  result = results.fieldnameIndex.getOrDefault(fieldName.toLowerAscii, -1)
+  if result < 0:
+    raise newODBCUnknownFieldException("field \"" & fieldName & "\" not found in results")
+
 proc len*(results: SQLResults): int = results.rows.len
 
 proc index*(results: SQLResults, name: string): int =

--- a/odbc/odbcfields.nim
+++ b/odbc/odbcfields.nim
@@ -24,7 +24,6 @@ type
   SQLResults* = object
     fieldnameIndex: FieldIdxs
     colFields: seq[SQLField]
-    fieldNames: Table[string, int]
     rows*: seq[SQLRow]
     curRow*: int
 
@@ -38,41 +37,46 @@ proc fields*(results: SQLResults, index: int): SQLField = results.colFields[inde
 
 proc len*(results: SQLResults): int = results.rows.len
 
-proc fromField*(results: SQLResults, name: string, rowIdx = -1): SQLData =
-  let idx = results.fieldnames[name]
-  if rowIdx == -1:
-    result = results.rows[results.curRow][idx]
-  else:
-    result = results.rows[rowIdx][idx]
-    
 proc index*(results: SQLResults, name: string): int =
-  result = results.fieldnames[name]
+  result = results.fieldnameIndex[name]
 
-proc data*(results: var SQLResults, fieldName: string, rowIdx: int = -1): SQLData =
-  # table.withValue(key, value) do:
-  results.fieldnameIndex.withValue(fieldName.toLowerAscii, fldIdx) do:
-    # value found
-    if rowIdx < 0:
-      result = results[results.curRow][fldIdx[]] 
-    else:
-      result = results[rowIdx][fldIdx[]]
-  do:
-    # fieldname not found
+proc tryData*(results: SQLResults, fieldName: string, rowIdx: int, value: var SQLData): bool {.inline.} =
+  ## Populates `value` if the field exists and returns true. If the field can't be found, returns false.
+  ## If `rowIdx` < 0, `results`.curRow is used.
+  let idx = results.fieldnameIndex.getOrDefault(fieldName.toLowerAscii, -1)
+  if idx < 0: return
+  if rowIdx < 0:
+    value = results[results.curRow][idx]
+  else:
+    value = results[rowIdx][idx]
+  true
+
+## Populates `value` from the current row if the field exists and returns true, otherwise returns false.
+template tryData*(results: SQLResults, fieldName: string, value: var SQLData): bool = results.tryData(fieldName, results.curRow, value)    
+
+proc data*(results: SQLResults, fieldName: string, rowIdx: int = -1): SQLData =
+  ## Return the SQLData associated with a field and row in `results`.
+  ## If the field can't be found, an exception is raised.
+  if not results.tryData(fieldName, rowIdx, result):
     raise newODBCUnknownFieldException("Fieldname not found \"" & fieldName & "\"")
 
-proc data*(results: var SQLResults, field: SQLField): SQLData =
+proc data*(results: SQLResults, field: SQLField): SQLData =
   result = results[results.curRow][field.colIndex] 
 
-proc data*(results: var SQLResults, field: SQLField, rowIndex: int): SQLData =
+proc data*(results: SQLResults, field: SQLField, rowIndex: int): SQLData =
   result = results[rowIndex][field.colIndex] 
-    
+
+template data*(results: SQLResults, columnIndex: Natural): SQLData = results[results.curRow][columnIndex]
+template data*(results: SQLResults, columnIndex: Natural, rowIndex: Natural): SQLData = results[rowIndex][columnIndex]
+
+template fromField*(results: SQLResults, name: string, rowIdx = -1): SQLData {.deprecated: "use `data` instead".} = results.data(name, rowIdx)
+
 proc initSQLRow*: SQLRow =
   result = @[]
 
 proc initSQLResults*: SQLResults =
   result.rows = @[]
   result.colFields = @[]
-  result.fieldNames = initTable[string, int]()
   result.fieldnameIndex = initFieldIdxs()
 
 proc next*(results: var SQLResults) =

--- a/odbc/odbcparams.nim
+++ b/odbc/odbcparams.nim
@@ -165,14 +165,21 @@ proc readFromBuf(dataItem: var SQLData, buffer: ParamBuffer, indicator: int) =
   of dtBinary: dataItem.binVal = bufToSeq(buffer, indicator)
   of dtTime:
     var timestamp = cast[ptr SQL_TIMESTAMP_STRUCT_FRACTFIX](buffer)
-    const ms = 1_000_000
-    let
-      milliseconds = timestamp.Fraction div ms
-      microseconds = (timestamp.Fraction mod ms) div 1_000
-      # Nanoseconds is not cropped and contains the full nanoseconds to the nearest second.
-      # Weeks is not populated.
-    dataItem.timeVal = initTimeInterval(timestamp.Fraction, microseconds, milliseconds, timestamp.Second, timestamp.Minute, timestamp.Hour,
-        timestamp.Day - 1, 0, timestamp.Month, timestamp.Year) # day is 1 indexed in SQL
+    # The `weeks` field is not populated.
+    when defined(rawTimes):
+      # Don't populate milliseconds/microseconds, and nanoseconds is the uncropped full fraction component.
+      dataItem.timeVal = initTimeInterval(timestamp.Fraction, 0, 0, timestamp.Second, timestamp.Minute, timestamp.Hour,
+          timestamp.Day - 1, 0, timestamp.Month, timestamp.Year) # day is 1 indexed in SQL
+    else:
+      # Default behaviour is to populate milliseconds, microseconds and nanoseconds.
+      const ms = 1e6.int
+      let
+        milliseconds = timestamp.Fraction div ms
+        msRemaining = timestamp.Fraction mod ms
+        microseconds = msRemaining div 1_000
+        nanoseconds = msRemaining mod 1_000
+      dataItem.timeVal = initTimeInterval(nanoseconds, microseconds, milliseconds, timestamp.Second, timestamp.Minute, timestamp.Hour,
+          timestamp.Day - 1, 0, timestamp.Month, timestamp.Year) # day is 1 indexed in SQL
   when defined(odbcdebug):
     echo "Read buffer (first 255 bytes): ", repr(cast[ptr array[0..255, byte]](buffer))
 

--- a/odbc/odbcparams.nim
+++ b/odbc/odbcparams.nim
@@ -188,8 +188,7 @@ proc writeToBuf(dataItem: SQLData, buffer: ParamBuffer) =
   of dtFloat: cast[ptr float](buffer)[] = dataItem.floatVal
   of dtBinary: dataItem.binVal.seqToBuf(buffer, dataItem.binVal.len)
   of dtTime:
-    var
-      timestamp = cast[ptr SQL_TIMESTAMP_STRUCT_FRACTFIX](buffer)
+    var timestamp = cast[ptr SQL_TIMESTAMP_STRUCT_FRACTFIX](buffer)
     timestamp.Fraction = dataItem.timeVal.nanoseconds.int32
     timestamp.Second = dataItem.timeVal.seconds.SqlUSmallInt
     timestamp.Minute = dataItem.timeVal.minutes.SqlUSmallInt
@@ -245,7 +244,6 @@ proc dbQuote*(s: string): string =
     else: add(result, c)
   add(result, '\'')
 
-
 proc bindParams*(sqlStatement: var string, params: var SQLParams, rptState: var ODBCReportState) =
   # Parameters: for ApacheDrill we resolve params and clear params collection
   var
@@ -267,8 +265,6 @@ proc bindParams*(sqlStatement: var string, params: var SQLParams, rptState: var 
       sql.add(s)
   params.clear()
   sqlStatement = sql
-
-
 
 proc bindParams(handle: SqlHStmt, params: var SQLParams, rptState: var ODBCReportState) =
   # Parameters: ODBC can't use named parameters, so we need to do a string lookup
@@ -310,7 +306,7 @@ proc bindParams(handle: SqlHStmt, params: var SQLParams, rptState: var ODBCRepor
     when defined(odbcdebug):
       echo &"Binding slot {idx} (real index {paramIdxRef})"
       echo &" Data Type {curParam.field.dataType}, value type {curParam.field.cType}, param type {curParam.field.sqlType}"
-      echo &" Column size {colSize}, digits {curParam.field.digits}, buffer len {paramDataSize}"
+      echo &" Column size {colSize}, digits {curParam.field.digits}, buffer len {paramDataSize}\n"
 
     var res = SQLBindParameter(handle,
       paramIdx.SqlUSmallInt,
@@ -318,12 +314,12 @@ proc bindParams(handle: SqlHStmt, params: var SQLParams, rptState: var ODBCRepor
       curParam.field.cType,
       curParam.field.sqlType,
       colSize,                            # column size (for string types this is number of characters)
-      curParam.field.digits.TSqlSmallInt, # digit size
+      curParam.field.digits.TSqlSmallInt, # digit size (scale)
       params.paramBuf[paramIdxRef],       # pointer to data to bind
       paramDataSize,                      # byte count of data
       addr(params.paramIndBuf[paramIdxRef])
       )
-    when defined(odbcdebug): echo &"Param ind after bind is {params.paramIndBuf[paramIdxRef]}"
+    when defined(odbcdebug): echo &"Param ind after bind is {params.paramIndBuf[paramIdxRef]}\n"
     rptOnErr(rptState, res, "SQLBindParameter", handle, SQL_HANDLE_STMT.TSqlSmallInt)
 
     paramIdx += 1

--- a/odbc/odbcparams.nim
+++ b/odbc/odbcparams.nim
@@ -140,7 +140,6 @@ proc distributeNanoseconds*(interval: TimeInterval): TimeInterval =
 proc distributeNanoseconds*(timeStamp: SQL_TIMESTAMP_STRUCT_FRACTFIX): TimeInterval =
   ## Populates fractional components milliseconds and microseconds from nanoseconds,
   ## and trims nanoseconds.
-  echo "<", timeStamp.Fraction
   result = initTimeInterval(
     timeStamp.Fraction, 0, 0, timestamp.Second, timestamp.Minute, timestamp.Hour,
     timestamp.Day - 1, 0, timestamp.Month, timestamp.Year)

--- a/odbc/odbctypes.nim
+++ b/odbc/odbctypes.nim
@@ -317,7 +317,12 @@ proc asBinary*(sqlData: SQLData): SQLBinaryData =
     result.setLen floatSize
     for idx, b in buf:
       result[idx] = b
-  of dtTime: raise newODBCException("cannot transform " & sqlData.timeVal.type.name & " to binary")
+  of dtTime:
+    const timeSize = sqlData.timeVal.sizeOf
+    var buf = cast[array[timeSize, byte]](sqlData.timeVal)
+    result.setLen timeSize
+    for idx, b in buf:
+      result[idx] = b
   of dtBinary:
     result.setLen sqlData.binVal.len
     for idx, b in sqlData.binVal: result[idx] = b

--- a/odbc/odbcutils.nim
+++ b/odbc/odbcutils.nim
@@ -1,4 +1,4 @@
-import odbcsql, odbcerrors, odbcconnections, odbcreporting, odbchandles
+import odbcsql, odbcerrors, odbcconnections, odbcreporting, odbchandles, times
 
 type
   SQLDriverAttribute* = tuple[key, value: string]
@@ -15,6 +15,23 @@ proc `$`*(driverInfos: seq[SQLDriverInfo]): string =
   result = ""
   for di in driverInfos:
     result &= $di & "\n"
+
+proc distributeNanoseconds*(interval: var TimeInterval) =
+  ## Populates fractional components milliseconds and microseconds from nanoseconds,
+  ## and trims nanoseconds.
+  const ms = 1_000_000
+  let
+    ns = interval.nanoseconds
+    msRemaining = ns mod ms
+  interval.milliseconds = ns div ms
+  interval.microseconds = msRemaining div 1_000
+  interval.nanoseconds = msRemaining mod 1_000
+
+proc distributeNanoseconds*(interval: TimeInterval): TimeInterval =
+  ## Populates fractional components milliseconds and microseconds from nanoseconds,
+  ## and trims nanoseconds.
+  result = interval
+  result.distributeNanoseconds
 
 proc listDrivers*(con: ODBCConnection = nil): seq[SQLDriverInfo] =
   const

--- a/odbc/odbcutils.nim
+++ b/odbc/odbcutils.nim
@@ -16,23 +16,6 @@ proc `$`*(driverInfos: seq[SQLDriverInfo]): string =
   for di in driverInfos:
     result &= $di & "\n"
 
-proc distributeNanoseconds*(interval: var TimeInterval) =
-  ## Populates fractional components milliseconds and microseconds from nanoseconds,
-  ## and trims nanoseconds.
-  const ms = 1_000_000
-  let
-    ns = interval.nanoseconds
-    msRemaining = ns mod ms
-  interval.milliseconds = ns div ms
-  interval.microseconds = msRemaining div 1_000
-  interval.nanoseconds = msRemaining mod 1_000
-
-proc distributeNanoseconds*(interval: TimeInterval): TimeInterval =
-  ## Populates fractional components milliseconds and microseconds from nanoseconds,
-  ## and trims nanoseconds.
-  result = interval
-  result.distributeNanoseconds
-
 proc listDrivers*(con: ODBCConnection = nil): seq[SQLDriverInfo] =
   const
     driverBufLen = 256

--- a/odbc/odbcutils.nim
+++ b/odbc/odbcutils.nim
@@ -1,7 +1,7 @@
 import odbcsql, odbcerrors, odbcconnections, odbcreporting, odbchandles
 
 type
-  SQLDriverAttribute = tuple[key, value: string]
+  SQLDriverAttribute* = tuple[key, value: string]
   SQLDriverInfo* = object
     driver*: string
     attributes*: seq[SQLDriverAttribute]
@@ -45,9 +45,8 @@ proc listDrivers*(con: ODBCConnection = nil): seq[SQLDriverInfo] =
 
   direction = SQL_FETCH_FIRST
 
-  ret = SQLDrivers(env, direction,
-             driver.cstring, driverBufLen.TSqlSmallInt, addr driver_ret,
-             attr.cstring, attrBufLen.TSqlSmallInt, addr attr_ret)
+  ret = SQLDrivers(env, direction, driver.cstring, driverBufLen.TSqlSmallInt,
+    addr driver_ret, attr.cstring, attrBufLen.TSqlSmallInt, addr attr_ret)
   rptOnErr(rpt, ret, "sqlDrivers", env)
 
   while ret == SQL_SUCCESS or ret == SQL_SUCCESS_WITH_INFO:
@@ -82,8 +81,9 @@ proc listDrivers*(con: ODBCConnection = nil): seq[SQLDriverInfo] =
 
     direction = SQL_FETCH_NEXT
     result.add(newDriverInfo)
-    ret = SQLDrivers(env, direction,
-               driver, driverBufLen.TSqlSmallInt, addr driver_ret,
-               attr, attrBufLen.TSqlSmallInt, addr attr_ret)
+
+    ret = SQLDrivers(env, direction, driver, driverBufLen.TSqlSmallInt,
+      addr driver_ret, attr, attrBufLen.TSqlSmallInt, addr attr_ret)
+
   freeEnvHandle(env, rpt)
 

--- a/tests/all.nim
+++ b/tests/all.nim
@@ -6,21 +6,28 @@ var
   iniSettings: IniFile
   iniPath = getCurrentDir().joinPath("DBConnect.ini")
 
+#[
+
+Below we load database properties from an inifile.
+You can set these properties manually for your own database,
+or if you want to use the wininifiles module, here is an example layout:
+
+  [Database]
+  HostName=MyDBHost
+  Database=MyDatabaseName
+  UserName=MyUsername
+  Password=MyPassword
+  WinAuth=0
+
+Any database with access to run queries and create temporary tables can
+be used to run these tests.
+
+]#
+
 if not iniPath.fileExists: iniPath = getCurrentDir().joinPath("tests").joinPath("DBConnect.ini")
 if not iniSettings.loadIni(iniPath):
   echo "Could not find ini file ", iniSettings.filename
   quit()
-
-# Here we load database properties from an inifile.
-# You can set these properties manually, or if you want to use
-# the wininifiles module, here is an example layout:
-#
-# [Database]
-# HostName=MyDBHost
-# Database=MyDatabaseName
-# UserName=MyUsername
-# Password=MyPassword
-# WinAuth=0
 
 var connections = newSeq[tuple[name: string, connection: ODBCConnection]]()
 
@@ -62,6 +69,11 @@ for conDetails in connections.mitems:
   else:
     echo "Success, connected to host \"" & con.host & "\", database \"" & con.database & "\""
 
+  suite "Utilities":
+    test "List drivers":
+      # Can't be automatically checked.
+      echo con.listDrivers
+
   suite "Parameter tests (" & conDetails.name & ")":
 
     test "Simple parameters":
@@ -73,13 +85,44 @@ for conDetails in connections.mitems:
       check res[0][0].intVal == 5
       check res[0][1].intVal == 1
 
-    # TODO: Times loses nanoseconds when converted to SQL time
+    test "Accessing field data":
+      qry.statement = "SELECT 123 as data1, 456 as data2"
+      res = qry.executeFetch
+      let data = res.data("data1")
+      check data == 123
+      # Alternate access through `fields`.
+      check res.data(res.fields(0)) == 123
+      check res.data(res.fields(1)) == 456
+      # Access through column and row index.
+      check res.data(0, 0) == 123
+      check res.data(1) == 456
+
+    test "Conditional field access":
+      qry.statement = "SELECT 123 as data"
+      res = qry.executeFetch
+      var data: SQLData
+      check res.tryData("data", data)
+      check data == 123
+      data.reset
+      check not res.tryData("doota", data)
+      check data.kind == dtNull
+
     test "Times":
       let curTime = getTime()
       qry.statement = "SELECT ?a"
       qry.params["a"] = curTime
       res = qry.executeFetch
-      check res[0][0].timeVal == curTime.toTimeInterval
+      let timeVal = res[0][0].timeVal
+      let curTimeInterval =
+        when defined(rawTimes):
+          curTime.toTimeInterval
+        else:
+          # toTimeInterval doesn't set up milli/microseconds for us so for comparison we do this manually.
+          curTime.toTimeInterval.distributeNanoseconds
+      echo curTimeInterval
+      # Here we can directly compare to the nanosecond level because the date time value
+      # is not being converted and so does not lose precision.
+      check timeVal == curTimeInterval
 
     test "Nulls":
       qry.statement = "SELECT ?a"
@@ -98,7 +141,7 @@ for conDetails in connections.mitems:
       res = qry.executeFetch
       check res[0][0] == 4611686018427387904
       qry.statement = "SELECT ?a"
-      template testData: auto = pow(2.float64, 68.float64)
+      const testData = pow(2.float64, 68.float64)
       qry.params["a"] = testData
       res = qry.executeFetch
       check res[0][0] == testData
@@ -114,12 +157,17 @@ for conDetails in connections.mitems:
     test "Insert and Read":
       qry.statement = """
       SET NOCOUNT ON
-      CREATE TABLE #Temp (Name Varchar(255), textval varchar(255), intval int, timeval DateTime, boolval bit)
+      CREATE TABLE #Temp (Name Varchar(255), textval varchar(255), intval int, timeval DateTime2, boolval bit)
       INSERT INTO #Temp VALUES (?name, ?textval, ?intval, ?timeval, ?boolval)
       SELECT * FROM #Temp
       DROP TABLE #Temp
       """
-      let curTime = getTime().toTimeInterval
+      let curTime = 
+        when defined(rawTimes):
+          getTime().toTimeInterval
+        else:
+          # toTimeInterval doesn't set up milli/microseconds for us so for comparison we do this manually.
+          getTime().toTimeInterval.distributeNanoseconds
       qry.params["name"] = "testy"
       qry.params["textval"] = " testing "
       qry.params["intval"] = 99
@@ -132,11 +180,22 @@ for conDetails in connections.mitems:
       check res[0][0] == "testy"
       check res[0][1] == " testing "
       check res[0][2] == 99
-      # TODO: Time loses nanoseconds
-      #check res[0][3].timeVal == curTime
+      # Depending on the database's precision, milliseconds and below may be zero or
+      # a slightly different value to the one passed to the query. In this case a direct
+      # comparison will fail. Set the following to `false` to perform checks up to the 
+      # nearest second.
+      when true:
+        # Comparison up to nanosecond precision.
+        check res[0][3].timeVal == curTime
+      else:
+        # Checking up to one second difference from input.
+        let timeDiff = curTime - res[0][3].timeVal
+        check:
+          timeDiff.years == 0 and timeDiff.months == 0 and timeDiff.weeks == 0
+          timeDiff.days == 0 and timeDiff.minutes == 0 and timeDiff.seconds < 1
+
       check res[0][4] == true
-      check res.data(res.fields(0)) == "testy"
-      
+
     test "Volume Parameters":
       qry.statement = "SELECT ?id"
       var row: SQLRow

--- a/tests/all.nim
+++ b/tests/all.nim
@@ -93,6 +93,10 @@ for conDetails in connections.mitems:
       # Alternate access through `fields`.
       check res.data(res.fields(0)) == 123
       check res.data(res.fields(1)) == 456
+      check res.data(res.fields("data1")) == 123
+      check res.data(res.fields("data2")) == 456
+      expect ODBCFieldException:
+        discard res.fields("missing")
       # Access through column and row index.
       check res.data(0, 0) == 123
       check res.data(1) == 456

--- a/tests/all.nim
+++ b/tests/all.nim
@@ -100,6 +100,7 @@ for conDetails in connections.mitems:
       # Access through column and row index.
       check res.data(0, 0) == 123
       check res.data(1) == 456
+      check res.data(res.fieldIndex("data2")) == 456
 
     test "Conditional field access":
       qry.statement = "SELECT 123 as data"

--- a/tests/all.nim
+++ b/tests/all.nim
@@ -119,7 +119,7 @@ for conDetails in connections.mitems:
       res = qry.executeFetch
       let timeVal = res[0][0].timeVal
       let curTimeInterval =
-        when defined(rawTimes):
+        when defined(odbcRawTimes):
           curTime.toTimeInterval
         else:
           # toTimeInterval doesn't set up milli/microseconds for us so for comparison we do this manually.
@@ -168,7 +168,7 @@ for conDetails in connections.mitems:
       DROP TABLE #Temp
       """
       let curTime = 
-        when defined(rawTimes):
+        when defined(odbcRawTimes):
           getTime().toTimeInterval
         else:
           # toTimeInterval doesn't set up milli/microseconds for us so for comparison we do this manually.
@@ -191,10 +191,10 @@ for conDetails in connections.mitems:
       # nearest second.
       when true:
         # Comparison up to nanosecond precision.
-        check res[0][3].timeVal == curTime
+        check res.data("timeVal", 0).timeVal == curTime
       else:
         # Checking up to one second difference from input.
-        let timeDiff = curTime - res[0][3].timeVal
+        let timeDiff = curTime - res.data("timeVal").timeVal
         check:
           timeDiff.years == 0 and timeDiff.months == 0 and timeDiff.weeks == 0
           timeDiff.days == 0 and timeDiff.minutes == 0 and timeDiff.seconds < 1

--- a/tests/all.nim
+++ b/tests/all.nim
@@ -111,6 +111,8 @@ for conDetails in connections.mitems:
       data.reset
       check not res.tryData("doota", data)
       check data.kind == dtNull
+      check res.hasField("data")
+      check not res.hasField("doota")
 
     test "Times":
       let curTime = getTime()


### PR DESCRIPTION
  * Added `asBinary` support for times. All field types now allow conversion to `seq[byte]`.
  * Added `tryData` for `SQLResults`, allowing speculatively fetching values without raising an error if the field doesn't exist.
  * Added `fieldIndex`, `fields`, and `hasField` procs for `SQLResults`.
  * Added millisecond and microsecond population for time fields.
    Times now have microseconds and milliseconds populated and nanoseconds are appropriately truncated by default.
  * Added `distributeNanoseconds` to manually invoke sub-second field population from `nanoseconds` on a `TimeInterval`.
  * Added `stuffNanoseconds` to assemble the fractional part of a `TimeInterval` to nanoseconds.
  * Added `odbcRawTimes` compile-time switch to avoid populating milliseconds and microseconds or truncating nanoseconds.
    This leaves the entire sub-second fractional component represented in nanoseconds.
  * Added tests for `data`, `tryData`, `fieldIndex`, and `listDrivers`.
  * Exposed `SQLDriverAttribute`.
  * Deprecated `fromField` used with SQLResults, as it now does the same work as `data`.
  * `data` doesn't need `var SQLResults` any more.
  * Removed the internal variable `fieldNames`, a functional duplicate of `fieldnamesIndex` in SQLResults.
  * Tidied up the date time test, add option to only check times up to seconds precision.