### PR TITLE
Easier single statement queries and demoting quitProcs and finalisers

### DIFF
--- a/odbc.nim
+++ b/odbc.nim
@@ -32,10 +32,10 @@ type
     handle: SqlHStmt
     # statement is handled by a property getter/setter as setting the statement
     # triggers a search for parameters
-    statement: string
+    fStatement: string
     # This is the statement with "?name" replaced with "?" (ODBC doesn't allow named parameters)
     # odbcStatement is set up when the statement is set
-    odbcStatement: string
+    fOdbcStatement: string
     # metadata for result columns
     colFields: seq[SQLField]
     # dataBuf is the default buffer for reading data from ODBC for processing
@@ -198,13 +198,18 @@ proc `statement=`*(qry: var SQLQuery, statement: string) =
   # as this would alter the parameters and get confusing
   # we DO want to clear the parameters here
   if qry.opened: qry.close  # this will also handle clearing of buffers, but not clear params
-  qry.statement = statement
-  qry.params.setupParams(qry.statement)
-  qry.odbcStatement = qry.statement.odbcParamStatement
+  qry.fStatement = statement
+  qry.params.setupParams(qry.fStatement)
+  qry.fOdbcStatement = qry.fStatement.odbcParamStatement
 
 proc statement*(qry: var SQLQuery): string =
   ## Read current statement from query.
-  qry.statement
+  qry.fStatement
+
+proc odbcStatement*(qry: var SQLQuery): string =
+  ## Read current statement as ODBC sees it. Named parameters are replaced with `?`.
+  qry.fOdbcStatement
+
 
 template setup(qry: var SQLQuery) =
   # if not already set up, allocates memory and a new statement handle

--- a/odbc.nim
+++ b/odbc.nim
@@ -227,7 +227,7 @@ template bindParams(qry: var SQLQuery) =
   # in place substitution for a bit less typing
   #apache drill has no concept of parameters so we resolve them before sending query
   if qry.con.serverType == ApacheDrill:
-    qry.odbcStatement.bindParams(qry.params, qry.con.reporting)
+    qry.fOdbcStatement.bindParams(qry.params, qry.con.reporting)
   else:
     qry.handle.bindParams(qry.params, qry.con.reporting)
 

--- a/odbc/odbcfields.nim
+++ b/odbc/odbcfields.nim
@@ -33,7 +33,15 @@ proc `[]`*(results: SQLResults, index: int): SQLRow =
 proc add*(results: var SQLResults, row: SQLRow) =
   results.rows.add(row)
 
+proc fieldCount*(results: SQLResults): int = results.colFields.len
+
 proc fields*(results: SQLResults, index: int): SQLField = results.colFields[index]
+
+iterator fields*(results: SQLResults): SQLField =
+  var idx: int
+  while idx < results.colFields.len:
+    yield results.colFields[idx]
+    idx.inc
 
 proc fields*(results: SQLResults, fieldName: string): SQLField =
   let idx = results.fieldnameIndex.getOrDefault(fieldName.toLowerAscii, -1)

--- a/odbc/odbcjson.nim
+++ b/odbc/odbcjson.nim
@@ -3,7 +3,7 @@ import odbcfields, odbctypes, json, unicode, tables, strformat
 proc toJson*(data: SQLData): JsonNode =
   case data.kind:
     of dtNull:
-      result.kind = JNull
+      result = newJNull()
     of dtString:
       result = % $(data.strVal)
     of dtInt:

--- a/odbc/odbcreporting.nim
+++ b/odbc/odbcreporting.nim
@@ -1,5 +1,3 @@
-import odbcsql
-
 type
   ODBCReportLevel* = enum rlNone, rlErrors, rlErrorsAndInfo
   ODBCReportDestination* = enum rdStore, rdEcho, rdFile, rdCallBack

--- a/odbc/odbctypes.nim
+++ b/odbc/odbctypes.nim
@@ -338,8 +338,7 @@ proc isNull*(sqlData: SQLData): bool = sqlData.kind == dtNull
 proc kind*(data: SQLData): SQLDataType {.inline.} = data.kind
 
 proc `kind=`*(data: var SQLData, kind: SQLDataType) =
-  data.reset
-  data.kind = kind
+  data = SQLData(kind: kind)
 
 converter toBinary*(sqlData: SQLData): SQLBinaryData = sqlData.asBinary
 converter toString*(sqlData: SQLData): string = sqlData.asString


### PR DESCRIPTION
This PR adds some quality of life features for performing SQL statements without queries, and moves away from finalizers and quit procs as a default.

`-d:odbcUseQuitProc`

The behaviour of adding a quit proc to ensure connections are deallocated on quit is now demoted to be behind the `-d:odbcUseQuitProc` switch.

This was done for two reasons:

* They just aren't that useful because connections should be closed by the server anyway after a period of inactivity, so it isn't a good fit for default behaviour.
* #14 Seems to indicate data state is mutating whilst in process of the quit proc, which seems to suggest some kind of corruption (perhaps threading interaction on shutdown), so I'd rather demote this to a special case for now. Ultimately, destructors will do a better job than quit procs when they are release in Nim stable branch, and quit procs will likely become redundant for this purpose.

`-d:odbcFinalizers`

Finalisers have also been demoted to be behind a switch. This was done as a general effort to give control to the user to use their own management style. As part of this process, `freeQuery` is now publicly accessible.

`dbq`, `executeFetch(connection, statement)`, and `newQuery(connection, statement)`

To make simple queries easier, there is now a `dbq` macro that will let you set up and execute a 
query with parameters, fetch the data and free itself.

```nim
let result = connection.dbq(
  "SELECT * FROM table WHERE A = ?field1 AND B = ?field2",
  ("field1", "test value"), ("field2", "second test"))
```
Similarly `executeFetch` can be used without a query, though using it this way doesn't support parameters:

```nim
let result = connection.executeFetch("SELECT 1")
```

`newQuery` also now allows you to pass a statement to initialise and makes it a bit easier to chain queries to.
